### PR TITLE
clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,6 @@ serde_derive = "0.9"
 [features]
 default = ["serde-all"]
 serde-all = ["serde", "serde_json" ]
-nightly = ["multipart/nightly"]
+nightly = ["multipart/nightly", "clippy"]
 # Enable this when using the `#[service]` attribute from `anterofit_service_attr`
 service-attr = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ serde_json = { version = "0.9", optional = true }
 # Disabled until updated to serde 0.9
 # serde_xml = { version = "0.9.1", optional = true }
 
+clippy = { version = ">=0.0, <0.1", optional = true}
+
 [dependencies.multipart]
 version = "0.10"
 default-features = false

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -1,5 +1,7 @@
 //! Types which can take a boxed closure and execute it, preferably in the background.
 
+#![cfg_attr(feature="clippy", allow(boxed_local))]
+
 pub mod threaded;
 
 pub use mpmc::{Receiver, RecvIter, RecvIntoIter};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,10 @@
 //! the result will be available immediately. `Call` provides alternative methods wrapping
 //! `Future::poll()` and `Future::wait()` without external types so you
 //! have a choice over whether you want to use futures in your app or not.
+
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
+#![cfg_attr(feature="clippy", deny(clippy))]
 #![warn(missing_docs)]
 #![cfg_attr(feature = "nightly", feature(specialization))]
 #![recursion_limit="100"]

--- a/src/net/body.rs
+++ b/src/net/body.rs
@@ -357,12 +357,12 @@ enum FileField_ {
 }
 
 trait StreamField: Read + Send + 'static {
-    fn add_self(self: Box<Self>, name: String, filename: Option<String>, content_type: Option<Mime>, to: &mut Multipart);
+    fn add_self(self: Self, name: String, filename: Option<String>, content_type: Option<Mime>, to: &mut Multipart);
 }
 
 impl<T> StreamField for T where T: Read + Send + 'static {
-    fn add_self(self: Box<Self>, name: String, filename: Option<String>, content_type: Option<Mime>, to: &mut Multipart) {
-        to.add_stream(name, *self, filename, content_type);
+    fn add_self(self: Self, name: String, filename: Option<String>, content_type: Option<Mime>, to: &mut Multipart) {
+        to.add_stream(name, self, filename, content_type);
     }
 }
 

--- a/src/net/call.rs
+++ b/src/net/call.rs
@@ -59,8 +59,7 @@ impl<T> Call<T> {
     pub fn check(&mut self) -> Option<Result<T>> {
         match self.poll_no_task() {
             Ok(Async::Ready(val)) => Some(Ok(val)),
-            Ok(Async::NotReady) => None,
-            Err(Error::ResultTaken) => None,
+            Ok(Async::NotReady) | Err(Error::ResultTaken) => None,
             Err(e) => Some(Err(e))
         }
     }

--- a/src/net/call.rs
+++ b/src/net/call.rs
@@ -173,7 +173,7 @@ impl<T> PanicGuard<T> {
     /// Send a result, which will prevent the head being sent on-panic.
     pub fn complete(&mut self, res: Result<T>) {
         if let Some(tx) = self.tx.take() {
-            tx.complete(res);
+            let _ = tx.send(res);
         }
     }
 }

--- a/src/net/intercept.rs
+++ b/src/net/intercept.rs
@@ -182,6 +182,7 @@ impl<S: AsRef<str> + Send + Sync + 'static> Interceptor for AppendUrl<S> {
 ///
 /// This will not overwrite previous query pairs with the same key; it is left
 /// to the server to decide which duplicate keys to keep.
+#[derive(Default)]
 pub struct AppendQuery(Vec<(Cow<'static, str>, Cow<'static, str>)>);
 
 impl AppendQuery {

--- a/src/net/request.rs
+++ b/src/net/request.rs
@@ -141,8 +141,8 @@ impl RequestHead {
             vbuf.clear();
 
             // Errors here should be rare and usually indicate more serious problems.
-            let _ = write!(kbuf, "{}", key).expect("Error returned from Display::fmt()");
-            let _ = write!(vbuf, "{}", val).expect("Error returned from Display::fmt()");
+            write!(kbuf, "{}", key).expect("Error returned from Display::fmt()");
+            write!(vbuf, "{}", val).expect("Error returned from Display::fmt()");
 
             query_out.append_pair(&kbuf, &vbuf);
         }


### PR DESCRIPTION
Here are a few fixes for lints suggested by clippy.
I split it into multiple small commits in case there are things you disagree with.

The only one I'm not really sure about is a9d6f0a. It looks alright judging from the [multipart doc](https://docs.rs/multipart/0.10.1/multipart/client/lazy/struct.Multipart.html#method.add_stream), and I suppose `rustc` would complain if it was not.

Btw there is still a warning:

```
warning: use of deprecated item: renamed to `send`, #[warn(deprecated)] on by default
   --> src/net/call.rs:176:16
    |
176 |             tx.complete(res);
    |                ^^^^^^^^
```
A simple fix is to replace it with `tx.send(res)`, but then I was not sure how to handle the result (wether it should panic or not), so I left it.