### PR TITLE
fix delegate_impl! macro

### DIFF
--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -436,7 +436,7 @@ macro_rules! delegate_impl {
             method_impl!($getadapt; $($guts)*);
         }
 
-        impl_impl!($servicenm; [$($guts)*] $($rem)*);
+        delegate_impl!($servicenm; [$($guts)*] $($rem)*);
     );
     (
         $servicenm:ident; [$($guts:tt)*]


### PR DESCRIPTION
As far as I can tell, there is no `impl_impl!` macro defined anywhere in the crate so I assume you meant `delegate_impl!`.